### PR TITLE
LU-488 ptlrpc_connection_put() LASSERT(!cfs_hlist_unhashed(&conn->c_hash)

### DIFF
--- a/lustre/ptlrpc/connection.c
+++ b/lustre/ptlrpc/connection.c
@@ -97,7 +97,7 @@ int ptlrpc_connection_put(struct ptlrpc_connection *conn)
         if (!conn)
                 RETURN(rc);
 
-        LASSERT(!cfs_hlist_unhashed(&conn->c_hash));
+        LASSERT(cfs_atomic_read(&conn->c_refcount) > 1);
 
         /*
          * We do not remove connection from hashtable and


### PR DESCRIPTION
Hi Guys,

This pull request is for the patch that was created in response to ticket LU-488 (http://jira.whamcloud.com/browse/LU-488). The patch itself lives here: http://review.whamcloud.com/1074. This pull request reflects patchset 1 of this patch.

This patch hasn't been tested, although since it is simply a change to an assertion it might be trivial enough to be landed without testing. Let me know if this is not the case.

Prakash
# 

LU-488 ptlrpc_connection_put() LASSERT(!cfs_hlist_unhashed(&conn->c_hash))

Connection hash may be rehashed while ptlrpc_connection_put() is
called, ASSERT &conn->c_refcount > 1 instead of this.

Signed-off-by: Lai Siyao laisiyao@whamcloud.com
Change-Id: Iec6d35419e0c4d8497bd0b84c6210abc8eb23882
