### PR TITLE
LU-227 Use special make rule for LDISKFS_DEVEL

### DIFF
--- a/autoMakefile.am
+++ b/autoMakefile.am
@@ -20,7 +20,7 @@ EXTRA_DIST += debian/*
 endif
 
 if LDISKFS_ENABLED
-if !LDISKFS_IN_KERNEL
+if LDISKFS_DEVEL
 
 EXTRA_DIST += @SYMVERFILE@
 
@@ -39,6 +39,13 @@ EXTRA_DIST += @SYMVERFILE@
 		"*** - @LDISKFS_OBJ@/ldiskfs/@SYMVERFILE@\n"; \
 		exit 1; \
 	fi
+else
+if !LDISKFS_IN_KERNEL
+@SYMVERFILE@: @LDISKFS_DIR@/@SYMVERFILE@
+	touch @SYMVERFILE@
+	-grep -v ldiskfs @SYMVERFILE@ > @SYMVERFILE@.old
+	cat @SYMVERFILE@.old @LDISKFS_DIR@/@SYMVERFILE@ > @SYMVERFILE@
+endif
 endif
 endif
 


### PR DESCRIPTION
Hey Ned,

Is this the correct way to implement the conditional check we need to add for the @SYMVERFILE@ make rule?

Prakash

The LDISKFS_DEVEL conditional needs to be checked in order to properly support
using the lustre-ldiskfs-devel while still supporting the in-tree or in-kernel
lustre sources. Thus, if LDISKFS_DEVEL is true, a special @SYMVERFILE@ make
rule is needed. Otherwise, use the same @SYMVERFILE@ make rule as before.

Signed-off-by: Prakash Surya surya1@llnl.gov
Change-Id: I1f99f536fedfeeeeaee6e04f31e2102d397bf646
