### PR TITLE
LU-499 grant/cancel_rate are static when OST is idle

### DIFF
--- a/lustre/include/lustre_dlm.h
+++ b/lustre/include/lustre_dlm.h
@@ -511,6 +511,8 @@ struct ldlm_namespace {
          * ldlm lock stats
          */
         struct lprocfs_stats  *ns_stats;
+
+        unsigned               ns_stopping:1;   /* namespace cleanup */
 };
 
 static inline int ns_is_client(struct ldlm_namespace *ns)

--- a/lustre/ldlm/ldlm_pool.c
+++ b/lustre/ldlm/ldlm_pool.c
@@ -1264,9 +1264,9 @@ void ldlm_pools_recalc(ldlm_side_t client)
                 cfs_spin_lock(&ns->ns_lock);
                 /*
                  * skip ns which is being freed, and we don't want to increase
-                 * its refcount again, not even temporarily. bz21519.
+                 * its refcount again, not even temporarily. bz21519 & LU-499.
                  */
-                if (cfs_atomic_read(&ns->ns_bref) == 0) {
+                if (ns->ns_stopping) {
                         skip = 1;
                 } else {
                         skip = 0;

--- a/lustre/ldlm/ldlm_resource.c
+++ b/lustre/ldlm/ldlm_resource.c
@@ -619,6 +619,7 @@ struct ldlm_namespace *ldlm_namespace_new(struct obd_device *obd, char *name,
         ns->ns_timeouts           = 0;
         ns->ns_orig_connect_flags = 0;
         ns->ns_connect_flags      = 0;
+        ns->ns_stopping           = 0;
         rc = ldlm_namespace_proc_register(ns);
         if (rc != 0) {
                 CERROR("Can't initialize ns proc, rc %d\n", rc);
@@ -832,6 +833,9 @@ void ldlm_namespace_free_prior(struct ldlm_namespace *ns,
                 return;
         }
 
+        cfs_spin_lock(&ns->ns_lock);
+        ns->ns_stopping = 1;
+        cfs_spin_unlock(&ns->ns_lock);
 
         /*
          * Can fail with -EINTR when force == 0 in which case try harder.


### PR DESCRIPTION
ldlm_pool_recalc() shouldn't be skipped if namespace->ns_bref eqauls
zero, instead a flag ns_stopping is added to mark ldlm namespace is
being freed.

Signed-off-by: Lai Siyao laisiyao@whamcloud.com
Change-Id: Ic6485c34ec3e9868ae531a4dc25aee969c374eb5
