### PR TITLE
LU-723 Move WALK_SPACE_HAS_DATA_SEM into ldiskfs

### DIFF
--- a/ldiskfs/kernel_patches/patches/ext4-walk-space-has-data-sem-rhel6.patch
+++ b/ldiskfs/kernel_patches/patches/ext4-walk-space-has-data-sem-rhel6.patch
@@ -1,0 +1,28 @@
+Add WALK_SPACE_HAS_DATA_SEM macro on "new" kernels
+
+In order for Lustre to correctly build its ldiskfs lvfs code, it needs
+some insight into whether the ext4_ext_walk_space function which ldiskfs
+was built against downs the i_data_sem internally. Thus, on kernels
+which exhibit this behaviour (i.e. 2.6.32 based kernels or newer), the
+WALK_SPACE_HAS_DATA_SEM macro is needed.
+
+Index: linux-stage/fs/ext4/ext4.h
+===================================================================
+--- linux-stage.orig/fs/ext4/ext4.h
++++ linux-stage/fs/ext4/ext4.h
+@@ -38,6 +38,15 @@
+  * The fourth extended filesystem constants/structures
+  */
+ 
++/*
++ * In order for Lustre to properly build its ldiskfs lvfs code, Lustre
++ * relies on this macro being set when the ext4_ext_walk_space function
++ * internally downs the i_data_sem semaphore. Thus, this macro is needed
++ * on kernels which exhibit this behavior (i.e. 2.6.32 based kernels or
++ * newer).
++ */
++#define WALK_SPACE_HAS_DATA_SEM 1
++
+ /*
+  * Define EXT4FS_DEBUG to produce debug messages
+  */

--- a/ldiskfs/kernel_patches/series/ldiskfs-2.6-rhel6.series
+++ b/ldiskfs/kernel_patches/series/ldiskfs-2.6-rhel6.series
@@ -30,3 +30,4 @@ ext4-back-dquot-to-rhel6.patch
 ext4-nocmtime-2.6-rhel5.patch
 ext4-export-64bit-name-hash.patch
 ext4-vmalloc-rhel6.patch
+ext4-walk-space-has-data-sem-rhel6.patch

--- a/lustre/autoconf/lustre-core.m4
+++ b/lustre/autoconf/lustre-core.m4
@@ -2128,27 +2128,6 @@ EXTRA_KCFLAGS="$tmp_flags"
 ])
 
 #
-# LC_WALK_SPACE_HAS_DATA_SEM
-#
-# 2.6.32 ext4_ext_walk_space() takes i_data_sem internally.
-#
-AC_DEFUN([LC_WALK_SPACE_HAS_DATA_SEM],
-[AC_MSG_CHECKING([if ext4_ext_walk_space() takes i_data_sem])
-WALK_SPACE_DATA_SEM="$(awk 'BEGIN { in_walk_space = 0 }                                 \
-                            /^int ext4_ext_walk_space\(/ { in_walk_space = 1 }          \
-                            /^}/ { if (in_walk_space) in_walk_space = 0 }               \
-                            /i_data_sem/ { if (in_walk_space) { print("yes"); exit } }' \
-                       $LINUX/fs/ext4/extents.c)"
-if test x"$WALK_SPACE_DATA_SEM" == xyes ; then
-       AC_DEFINE(WALK_SPACE_HAS_DATA_SEM, 1,
-                 [ext4_ext_walk_space takes i_data_sem])
-       AC_MSG_RESULT([yes])
-else
-       AC_MSG_RESULT([no])
-fi
-])
-
-#
 # LC_QUOTA64
 #
 # Check if kernel has been patched for 64-bit quota limits support.
@@ -2364,7 +2343,6 @@ AC_DEFUN([LC_PROG_LINUX],
          LC_BLK_QUEUE_MAX_SECTORS
          LC_BLK_QUEUE_MAX_SEGMENTS
          LC_EXT4_SINGLEDATA_TRANS_BLOCKS_SB
-         LC_WALK_SPACE_HAS_DATA_SEM
 
          #
          if test x$enable_server = xyes ; then


### PR DESCRIPTION
In order for Lustre to correctly build its ldiskfs lvfs code, it needs
some insight into whether the ext4_ext_walk_space function which ldiskfs
was build against downs the i_data_sem semaphore internally.

Rather than relying on an ugly autoconf test to probe the internals of
the ext4_ext_walk_space function and then set an AC_DEFINE, the
responsibility of defining the correct macro was moved into the ldiskfs
stack. This means that rather than checking, we assume we need the macro
needed on 2.6.32 and newer based kernels, but I feel assumption is
perfectly reasonable.

The main reason this change is needed is to facilitate building Lustre
without full kernel sources using an external ldiskfs development
package.

Signed-off-by: Prakash Surya surya1@llnl.gov
Change-Id: I9bd12184671955289fd8b93117fef09a8f644af0
