### PR TITLE
b=1282 Update /etc/init.d/lnet for Lustre 2.1

### DIFF
--- a/lustre/scripts/lnet
+++ b/lustre/scripts/lnet
@@ -22,15 +22,22 @@ declare -r TOP_MODULES=(	\
 	obdecho			\
 	llite			\
 	lustre			\
-	osc			\
 	lov			\
+	osc			\
+	osd_ldiskfs		\
+	cmm			\
+	mdt			\
+	mdd			\
 	mds			\
 	mdc			\
 	mgs			\
 	mgc			\
-	ost			\
 	obdfilter		\
+	ost			\
+	fid			\
+	lmv			\
 	lquota			\
+	fld			\
 	ptlrpc			\
 )
 declare -r BOTTOM_MODULES=(	\


### PR DESCRIPTION
The /etc/init.d/lnet script needed to be updated to reflect the set of
modules that are used in Lustre 2.1.

Signed-off-by: Prakash Surya surya1@llnl.gov
Change-Id: If6e2b249de5e47732abdb62ee062cb0f369185e2
