### PR TITLE
log lfs setstripe commands to syslog

### DIFF
--- a/lustre/doc/lfs-setstripe.1
+++ b/lustre/doc/lfs-setstripe.1
@@ -171,6 +171,11 @@ Add specified components to an existing composite file.
 .B --component-del
 Delete specified the components from an existing file. Deletion must start
 with the last component.
+.SH LOGGING
+Upon success, lfs setstripe target paths are logged via syslog.
+.TP
+Messages are logged to facility daemon.info with keyword "lfs_arguments" to identify the messages.  An example message is:
+.B lfs_arguments jobid=2383 node=pascal23 path="/p/lustre1/doe/test.4"
 .SH EXAMPLES
 .TP
 .B $ lfs setstripe -S 128k -c 2 /mnt/lustre/file1


### PR DESCRIPTION
To help guide PFL implementation, log the path arguments to lfs setstripe
when issued by users, along with the hostname and slurm JobID.  The
information is logged to syslog.  The syslog message is formatted
like:

lfs_arguments jobid=29383 node=pascal23 \
       path="/mnt/lustre/olaf-test.4"

One such message is logged for each path the user specifies.

The syslog priority is (LOG_DAEMON | LOG_INFO). The lfs-setstripe.1 man page describes the syslog output and specifies the priority.

I tested this by:
* building and running on oslici and confirmed the message in spunk was properly parsed.
* building and running on oslic10 under slurm and confirmed the hostname and slurm Job ID were correct
* building and running both with and without a Job ID set, and with an argument list longer than the buffer size (to confirm the buffer was not overflowed).
