### PR TITLE
LU-12836 osd-zfs: Catch all ZFS pool change events

### DIFF
--- a/lustre/scripts/Makefile.am
+++ b/lustre/scripts/Makefile.am
@@ -68,7 +68,8 @@ ha_SCRIPTS = Lustre.ha_v2
 
 if ZFS_ENABLED
 zedletdir = $(sysconfdir)/zfs/zed.d/
-zedlet_SCRIPTS = statechange-lustre.sh
+zedlet_SCRIPTS = statechange-lustre.sh vdev_attach-lustre.sh \
+		 vdev_remove-lustre.sh vdev_clear-lustre.sh
 endif
 
 scriptlibdir = @libexecdir@/@PACKAGE@
@@ -93,6 +94,7 @@ EXTRA_DIST = license-status lustre_rmmod ldev lc_mon lhbadm \
 	     $(addsuffix .in,$(genscripts)) lfs_migrate lustre_req_history \
 	     lustre lsvcgss lc_common haconfig Lustre.ha_v2 dkms.mkconf \
 	     zfsobj2fid ko2iblnd-probe statechange-lustre.sh \
+	     vdev_attach-lustre.sh vdev_remove-lustre.sh vdev_clear-lustre.sh \
 	     bash-completion/lustre bash-completion/lctl bash-completion/lfs
 
 CLEANFILES = $(genscripts)

--- a/lustre/scripts/statechange-lustre.sh
+++ b/lustre/scripts/statechange-lustre.sh
@@ -29,6 +29,10 @@
 #   2: zpool missing
 #   3: zfs missing
 #   4: Pool status neither "ONLINE" nor "DEGRADED
+#
+# This script is also symlinked as vdev_attach-lustre.sh, vdev_remove-lustre.sh
+# and vdev_clear-lustre.sh, since it needs to take the same action on those
+# ZFS events as well.
 
 [ -f "${ZED_ZEDLET_DIR}/zed.rc" ] && . "${ZED_ZEDLET_DIR}/zed.rc"
 . "${ZED_ZEDLET_DIR}/zed-functions.sh"

--- a/lustre/scripts/vdev_attach-lustre.sh
+++ b/lustre/scripts/vdev_attach-lustre.sh
@@ -1,0 +1,1 @@
+statechange-lustre.sh

--- a/lustre/scripts/vdev_clear-lustre.sh
+++ b/lustre/scripts/vdev_clear-lustre.sh
@@ -1,0 +1,1 @@
+statechange-lustre.sh

--- a/lustre/scripts/vdev_remove-lustre.sh
+++ b/lustre/scripts/vdev_remove-lustre.sh
@@ -1,0 +1,1 @@
+statechange-lustre.sh


### PR DESCRIPTION
This change adds the following symlinks:

  vdev_attach-lustre -> statechange-lustre.sh
  vdev_remove-lustre -> statechange-lustre.sh
  vdev_clear-lustre -> statechange-lustre.sh

This makes it so the statechange-lustre.sh script is also called on
all ZFS events that could change the pool state.

Lustre-change: https://review.whamcloud.com/43552
Lustre-commit: e11a47da71a2e2482e4c4cf582d663cd76a2ecab

Signed-off-by: Tony Hutter <hutter2@llnl.gov>
Change-Id: I18edc86749e8ab91bb45f21aafd3fd47e78cbaef
Reviewed-by: Olaf Faaland-LLNL <faaland1@llnl.gov>
Reviewed-by: Nathaniel Clark <nclark@whamcloud.com>
Signed-off-by: Minh Diep <mdiep@whamcloud.com>